### PR TITLE
bugfix: fix data structure for metric value

### DIFF
--- a/gsm8k_cookbook.ipynb
+++ b/gsm8k_cookbook.ipynb
@@ -75,16 +75,23 @@
       "source": [
         "from ape import BaseMetric\n",
         "\n",
+        "@dataclass\n",
+        "class MetricResult:\n",
+        "  score: float\n",
+        "\n",
         "# Set up the metric\n",
         "class GSM8KMetric(BaseMetric):\n",
-        "    def compute(self, inputs: dict, gold: dict, pred: dict, trace=None):\n",
-        "        if not isinstance(pred, dict):\n",
-        "            return False\n",
-        "        if \"answer\" not in pred:\n",
-        "            return False\n",
-        "        return int(parse_integer_answer(str(gold[\"answer\"]))) == int(\n",
-        "            parse_integer_answer(str(pred))\n",
-        "        )"
+        "  def compute(self, inputs: dict, gold: dict, pred: dict, trace=None):\n",
+        "    if not isinstance(pred, dict):\n",
+        "      return MetricResult(score=0.0)\n",
+        "    if \"answer\" not in pred:\n",
+        "      return MetricResult(score=0.0)\n",
+        "\n",
+        "    is_correct = int(parse_integer_answer(str(gold[\"answer\"]))) == int(\n",
+        "        parse_integer_answer(str(pred[\"answer\"]))\n",
+        "    )\n",
+        "\n",
+        "    return MetricResult(score=float(is_correct))"
       ]
     },
     {

--- a/gsm8k_cookbook.ipynb
+++ b/gsm8k_cookbook.ipynb
@@ -74,10 +74,13 @@
       "outputs": [],
       "source": [
         "from ape import BaseMetric\n",
+        "from typing import Any, Dict, Optional\n",
+        "from dataclasses import dataclass\n",
         "\n",
         "@dataclass\n",
         "class MetricResult:\n",
         "  score: float\n",
+        "  intermediate_values: Optional[Dict[str, Any]] = None\n",
         "\n",
         "# Set up the metric\n",
         "class GSM8KMetric(BaseMetric):\n",


### PR DESCRIPTION
I tried this MIPRO example and figured that it calls `BootstrapFewShot` optimizer 
https://github.com/weavel-ai/Ape/blob/e77f7bf15cdedfac6e74f21923d56f559dc9fc1e/ape/optimizer/utils.py#L98-L105

This optimizer also calls `_bootstrap_one_example` https://github.com/weavel-ai/Ape/blob/e77f7bf15cdedfac6e74f21923d56f559dc9fc1e/ape/optimizer/bootstrap_fewshot.py#L193 where it requires the metric_value to be a dictionary with a `score` key instead of just boolean. Otherwise, the pipeline will return an error 

```shell
 Error: 'dict' object has no attribute 'score'. [ape.optimizer.utils] filename=bootstrap_fewshot.py lineno=206
```